### PR TITLE
Adds "/" to the list of escaped characters in ghost__host.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
 
 - name: "Setup ghost's docker container for {{ ghost__blog_name }}"
   docker_container:
-    name: 'ghost_{{ ghost__host | replace(".", "_") }}'
+    name: 'ghost_{{ ghost__host | regex_replace("[\.\/]", "_") }}'
     image: 'ghost:{{ ghost__version }}-alpine'
     env_file: "{{ ghost__base_dir }}/docker_env"
     mounts:


### PR DESCRIPTION
If you host your blog on a subdirectory, for example `/blog`, you'll get the error:

```
fatal: [172.105.0.166]: FAILED! => {"changed": false, "msg": "Error creating container: 400 Client Error: Bad Request (\"Invalid container name (ghost_sitename_com/blog), only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed\")"}
```

This is because the `/` isn't escaped.  You can use a root hostname, but then all the assets are broken, expecting them as well to be served from the root.

This PR instead adds '/' to the list of escaped characters when creating the docker container, making it safe to host your blog in a folder other than the root folder.